### PR TITLE
Clarify LLM proxy server docs

### DIFF
--- a/PLANNED_CHANGES.md
+++ b/PLANNED_CHANGES.md
@@ -136,3 +136,8 @@ After testing completion:
 - Proper mocking for cryptography dependencies
 - Error scenario testing
 - Integration workflow testing
+
+### Additional TODOs
+- [ ] Add environment variable support for TLS configuration (`VIBECTL_TLS_ENABLED`, `VIBECTL_TLS_CERT_FILE`, `VIBECTL_TLS_KEY_FILE`).
+- [ ] Implement `vibectl-server config` subcommands for showing, setting and validating server configuration as referenced in docs.
+- [ ] Align documentation and code on JWT secret environment variable naming (`VIBECTL_JWT_SECRET` vs `VIBECTL_JWT_SECRET_KEY`).

--- a/TODO.md
+++ b/TODO.md
@@ -472,3 +472,20 @@ Rather than patch-specific history, implement a comprehensive undo system that w
 - Enhanced JSON patch with variables and templating
 - Strategic merge patch with array merge strategies
 - Server-side apply integration for field management
+
+## vibectl-server CLI Enhancements
+
+Track server configuration and debugging commands removed from the
+documentation but still desirable for a polished server experience.
+
+### Planned Commands
+
+- `vibectl-server config show [--section <name>] [--format yaml|json]`
+- `vibectl-server config set <key> <value>`
+- `vibectl-server config get <key>`
+- `vibectl-server config validate [--config-file path]`
+- `vibectl-server config generate-secret [--output-file path]`
+- `vibectl-server config reset [--section <name>]`
+- `vibectl-server status [--include-secrets]`
+- `vibectl-server test-jwt [--generate-token subject]`
+- `vibectl-server config precedence`

--- a/examples/manifests/vibect-server/README.md
+++ b/examples/manifests/vibect-server/README.md
@@ -1,0 +1,32 @@
+# vibectl-server Demo Manifests
+
+This directory contains a minimal Kubernetes deployment for the `vibectl-server`.
+It is intended for quick local demos or testing with a single replica.
+
+## Contents
+
+- `configmap.yaml` – basic server configuration
+- `secret.yaml` – JWT secret used for token generation
+- `deployment.yaml` – single replica Deployment
+- `service.yaml` – NodePort Service exposing the gRPC port
+
+## Usage
+
+1. Apply the manifests:
+   ```bash
+   kubectl apply -f examples/manifests/vibect-server/
+   ```
+2. Generate a client token:
+   ```bash
+   kubectl exec deploy/vibectl-server -- \
+     vibectl-server generate-token demo-user --expires-in 30d
+   ```
+3. Note the Node IP of your cluster and configure vibectl:
+   ```bash
+   vibectl setup-proxy configure \
+     vibectl-server-insecure://TOKEN@NODE_IP:30551
+   ```
+
+Replace `TOKEN` with the JWT returned in step 2 and `NODE_IP` with a reachable
+node address. Once configured, you can use vibectl as usual and requests will be
+proxied through the deployed server.

--- a/examples/manifests/vibect-server/configmap.yaml
+++ b/examples/manifests/vibect-server/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vibectl-server-config
+  labels:
+    app: vibectl-server
+data:
+  config.yaml: |
+    server:
+      host: 0.0.0.0
+      port: 50051
+      require_auth: true
+      use_tls: false
+    jwt:
+      secret_key_file: /etc/vibectl/secret/jwt-secret
+      issuer: demo-proxy
+      expiration_days: 30

--- a/examples/manifests/vibect-server/deployment.yaml
+++ b/examples/manifests/vibect-server/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vibectl-server
+  labels:
+    app: vibectl-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vibectl-server
+  template:
+    metadata:
+      labels:
+        app: vibectl-server
+    spec:
+      containers:
+      - name: vibectl-server
+        image: ghcr.io/vibectl/vibectl-server:latest
+        args: ["serve", "--config", "/etc/vibectl/config/config.yaml"]
+        ports:
+        - containerPort: 50051
+        volumeMounts:
+        - name: config
+          mountPath: /etc/vibectl/config
+        - name: jwt-secret
+          mountPath: /etc/vibectl/secret
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: vibectl-server-config
+      - name: jwt-secret
+        secret:
+          secretName: vibectl-server-secret

--- a/examples/manifests/vibect-server/secret.yaml
+++ b/examples/manifests/vibect-server/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vibectl-server-secret
+  labels:
+    app: vibectl-server
+type: Opaque
+stringData:
+  jwt-secret: demo-secret-key

--- a/examples/manifests/vibect-server/service.yaml
+++ b/examples/manifests/vibect-server/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vibectl-server
+  labels:
+    app: vibectl-server
+spec:
+  type: NodePort
+  selector:
+    app: vibectl-server
+  ports:
+  - name: grpc
+    port: 50051
+    targetPort: 50051
+    nodePort: 30551


### PR DESCRIPTION
## Summary
- rewrite `docs/llm-proxy-server.md` into a concise guide
- add TODOs for missing TLS env vars and config commands
- create example manifests for deploying vibectl-server
- collect unimplemented server CLI commands in TODO.md

## Testing
- `make check` *(fails: Could not find a version that satisfies the requirement hatchling)*

------
https://chatgpt.com/codex/tasks/task_e_68426d2c953c83318893884749b53ee1