### PR TITLE
Update proxy server TLS docs

### DIFF
--- a/examples/manifests/vibectl-server/README.md
+++ b/examples/manifests/vibectl-server/README.md
@@ -1,0 +1,33 @@
+# vibectl-server ACME Example Manifests
+
+This directory contains a minimal setup to test the LLM proxy server with TLS certificates issued by `cert-manager` using a local Pebble ACME server.
+
+## Files
+
+- `pebble.yaml` – Deploys a Pebble ACME server and supporting resources.
+- `cluster-issuer.yaml` – Creates a `ClusterIssuer` that points cert-manager at the Pebble instance.
+- `deployment-tls.yaml` – Deploys the vibectl server with a `Certificate` resource so cert-manager automatically provisions TLS.
+
+## Usage Workflow
+
+1. **Deploy ACME infrastructure**
+
+   ```bash
+   kubectl apply -f examples/manifests/vibectl-server/pebble.yaml
+   kubectl apply -f examples/manifests/vibectl-server/cluster-issuer.yaml
+   ```
+
+2. **Deploy vibectl-server**
+
+   ```bash
+   kubectl apply -f examples/manifests/vibectl-server/deployment-tls.yaml
+   kubectl wait --for=condition=available deployment/vibectl-server -n vibectl-demo
+   ```
+
+3. **Verify TLS certificate**
+
+   ```bash
+   openssl s_client -connect vibectl-server.vibectl-demo.svc.cluster.local:443
+   ```
+
+Successful connection confirms the ACME workflow and TLS setup are functioning.

--- a/examples/manifests/vibectl-server/cluster-issuer.yaml
+++ b/examples/manifests/vibectl-server/cluster-issuer.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: vibectl-pebble
+spec:
+  acme:
+    server: https://pebble.pebble.svc:14000/dir
+    skipTLSVerify: true
+    email: test@example.com
+    privateKeySecretRef:
+      name: vibectl-pebble-account-key
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/examples/manifests/vibectl-server/deployment-tls.yaml
+++ b/examples/manifests/vibectl-server/deployment-tls.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vibectl-demo
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vibectl-server-cert
+  namespace: vibectl-demo
+spec:
+  secretName: vibectl-server-tls
+  issuerRef:
+    name: vibectl-pebble
+    kind: ClusterIssuer
+  dnsNames:
+  - vibectl-server.vibectl-demo.svc.cluster.local
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vibectl-server
+  namespace: vibectl-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vibectl-server
+  template:
+    metadata:
+      labels:
+        app: vibectl-server
+    spec:
+      containers:
+      - name: vibectl-server
+        image: ghcr.io/vibectl/vibectl-server:latest
+        args:
+        - serve
+        ports:
+        - containerPort: 443
+        volumeMounts:
+        - name: tls
+          mountPath: /tls
+          readOnly: true
+        env:
+        - name: VIBECTL_CONFIG_FILE
+          value: /etc/vibectl/server-config.yaml
+      volumes:
+      - name: tls
+        secret:
+          secretName: vibectl-server-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vibectl-server
+  namespace: vibectl-demo
+spec:
+  selector:
+    app: vibectl-server
+  ports:
+  - name: https
+    port: 443
+    targetPort: 443

--- a/examples/manifests/vibectl-server/pebble.yaml
+++ b/examples/manifests/vibectl-server/pebble.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pebble
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pebble
+  namespace: pebble
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pebble
+  template:
+    metadata:
+      labels:
+        app: pebble
+    spec:
+      containers:
+      - name: pebble
+        image: letsencrypt/pebble:latest
+        env:
+        - name: PEBBLE_VA_NOSLEEP
+          value: "1"
+        - name: PEBBLE_WFE_NONCEREJECT
+          value: "0"
+        ports:
+        - containerPort: 14000
+        - containerPort: 15000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pebble
+  namespace: pebble
+spec:
+  selector:
+    app: pebble
+  ports:
+  - name: https
+    port: 14000
+    targetPort: 14000
+  - name: challenge
+    port: 15000
+    targetPort: 15000


### PR DESCRIPTION
## Summary
- tweak current status section to mention ACME example
- expand ACME workflow instructions
- rename `deployment.yaml` to `deployment-tls.yaml` and update README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68471e21078083319aedc4e99bff65e0