### PR TITLE
Improve proxy ACME docs and add Pebble example

### DIFF
--- a/examples/manifests/vibectl-server/README.md
+++ b/examples/manifests/vibectl-server/README.md
@@ -71,6 +71,23 @@ This demonstrates:
 - Proper certificate verification with CA bundles
 - Production-ready TLS configuration
 
+## Local ACME Testing with Pebble
+
+Use the `pebble.yaml` manifest to run a local [Pebble](https://github.com/letsencrypt/pebble) instance and test the `serve-acme` command:
+
+```bash
+kubectl apply -f examples/manifests/vibectl-server/pebble.yaml
+kubectl wait --for=condition=ready pod -l app=pebble --timeout=60s
+
+# Run vibectl-server in ACME mode pointing at the Pebble service
+vibectl-server serve-acme \
+  --email test@example.com \
+  --domain localhost \
+  --directory-url http://pebble.pebble.svc.cluster.local:14000/dir
+```
+
+After certificates are issued you can configure vibectl using the NodePort service shown earlier.
+
 ## Troubleshooting
 
 ### Check server logs

--- a/examples/manifests/vibectl-server/pebble.yaml
+++ b/examples/manifests/vibectl-server/pebble.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pebble
+  labels:
+    app: pebble
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pebble
+  template:
+    metadata:
+      labels:
+        app: pebble
+    spec:
+      containers:
+      - name: pebble
+        image: letsencrypt/pebble:latest
+        args: ["-config", "/test/config/pebble-config.json"]
+        env:
+        - name: PEBBLE_VA_NOSLEEP
+          value: "1"
+        - name: PEBBLE_WFE_NONCEREJECT
+          value: "0"
+        ports:
+        - containerPort: 14000
+        - containerPort: 15000
+      - name: pebble-challtestsrv
+        image: letsencrypt/pebble-challtestsrv:latest
+        env:
+        - name: PEBBLE_VA_NOSLEEP
+          value: "1"
+        ports:
+        - containerPort: 8055
+        - containerPort: 8053
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pebble
+  labels:
+    app: pebble
+spec:
+  type: ClusterIP
+  selector:
+    app: pebble
+  ports:
+  - name: acme
+    port: 14000
+    targetPort: 14000
+  - name: http-01
+    port: 8055
+    targetPort: 8055
+  - name: dns-01
+    port: 8053
+    targetPort: 8053


### PR DESCRIPTION
## Summary
- document ACME integration for vibectl-server and mention Pebble test manifest
- update example README with Pebble instructions
- add a kubernetes manifest to run Pebble locally

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684731ab41cc83319dbf73b5cd1e2b62